### PR TITLE
Corrected OpenZeppelin typo in index.tsx

### DIFF
--- a/src/components/WorkList/index.tsx
+++ b/src/components/WorkList/index.tsx
@@ -225,7 +225,7 @@ const WorkList = () => {
                   <div className={classes.moduleInfo}>
                     <h3>Governor Module</h3>
                     <p className={classes.description}>
-                      Use an Open-Zepellin style Governor contract to control an
+                      Use the OpenZeppelin style Governor contract to control an
                       Avatar
                     </p>
                     <div className={classes.links}>


### PR DESCRIPTION
Just corrected a little typo of OpenZeppelin that I found on the website [here](https://www.gnosisguild.org/)